### PR TITLE
Update SICP-Solution-Exercise-1-31.md

### DIFF
--- a/content/post/SICP-Solution-Exercise-1-31.md
+++ b/content/post/SICP-Solution-Exercise-1-31.md
@@ -67,6 +67,6 @@ This can be done like this:
   (define (iter a result)
     (if (> a b)
         result
-        (iter (next a) (* a result))))
+        (iter (next a) (* (term a) result))))
   (iter a 1))
 ```


### PR DESCRIPTION
The iterative definition of product needs to use the term function when contributing to the running product.