### PR TITLE
Update sicp-solution-exercise-1-31

### DIFF
--- a/content/post/sicp-solution-exercise-1-31.md
+++ b/content/post/sicp-solution-exercise-1-31.md
@@ -67,6 +67,6 @@ This can be done like this:
   (define (iter a result)
     (if (> a b)
         result
-        (iter (next a) (* a result))))
+        (iter (next a) (* (term a) result))))
   (iter a 1))
 ```


### PR DESCRIPTION
Inside the product-iter, the procedure iter is called with the second argument (* a result)  which would not result in a procedure analogous product, instead the correct version would be to call iter with the second argumet equal with (* (term a) result)