### PR TITLE
updated Exercise 1.29

### DIFF
--- a/solutions/chapter-1/Exercise-1-29.rkt
+++ b/solutions/chapter-1/Exercise-1-29.rkt
@@ -16,7 +16,7 @@
   (define h (/ (- b a) n))
   (define (add-2h x) (+ x h h))
   (* (+ (f a)
-        (* 2 (sum f a       add-2h b))
+        (* 2 (sum f (add-2h a) add-2h (- b h)))
         (* 4 (sum f (+ a h) add-2h b))
         (f b))
      (/ h 3)))


### PR DESCRIPTION
The corrected list has 2 problems.  First, the initial value `a` should be `(add-2h a)`.  For the current problem where `a`  is zero and we are taking the cube, this is not an issue.  But for other values of `a`,  this needs to be changed.   Second, the final value `b` should be `(- b h)`.   As this line handles the **even** case,  the computation of `a + n * h)` will equal `b` which is then included in the sum.  But it should be excluded, therefore I set the final value to `(- b h)`.







