### PR TITLE
Fix exercise 1 29

### DIFF
--- a/content/post/sicp-solution-exercise-1-29.md
+++ b/content/post/sicp-solution-exercise-1-29.md
@@ -38,7 +38,7 @@ This equation can be implemented in a manner that reuse the `sum` function that 
   (define h (/ (- b a) n))
   (define (add-2h x) (+ x h h))
   (* (+ (f a)
-        (* 2 (sum f a       add-2h b))
+        (* 2 (sum f (add-2h a) add-2h (- b h)))
         (* 4 (sum f (+ a h) add-2h b))
         (f b))
      (/ h 3)))

--- a/solutions/chapter-1/Exercise-1-29.rkt
+++ b/solutions/chapter-1/Exercise-1-29.rkt
@@ -17,7 +17,7 @@
   (define (add-2h x) (+ x h h))
   (* (+ (f a)
         (* 2 (sum f (add-2h a) add-2h (- b h)))
-        (* 4 (sum f (+ a h) add-2h b))
+        (* 4 (sum f (+ a h)    add-2h b))
         (f b))
      (/ h 3)))
 
@@ -30,4 +30,3 @@
 
 (display (integral-simpson cube 0 1.0 100)) (newline)
 (display (integral-simpson cube 0 1.0 1000)) (newline)
-

--- a/solutions/chapter-1/Exercise-1-29.rkt
+++ b/solutions/chapter-1/Exercise-1-29.rkt
@@ -16,7 +16,7 @@
   (define h (/ (- b a) n))
   (define (add-2h x) (+ x h h))
   (* (+ (f a)
-        (* 2 (sum f a       add-2h b))
+        (* 2 (sum f (add-2h a) add-2h (- b h)))
         (* 4 (sum f (+ a h) add-2h b))
         (f b))
      (/ h 3)))

--- a/solutions/chapter-1/Exercise-1-29.rkt
+++ b/solutions/chapter-1/Exercise-1-29.rkt
@@ -30,3 +30,4 @@
 
 (display (integral-simpson cube 0 1.0 100)) (newline)
 (display (integral-simpson cube 0 1.0 1000)) (newline)
+


### PR DESCRIPTION
The corrected line has 2 problems.

The initial value a should be (add-2h a). For the current problem, where a is zero and we are taking the cube, this is not an issue. But for other values of a, this needs to be changed.
The final value b should be (- b h). As this line handles the even case, the computation of (a + n * h) will equal b which is then included in the sum. But it should be excluded, therefore I set the final value to (- b h). For high value of n this may not be an issue. But for low values, it is significant. If n is 6 in this problem, the original code gives a result of 0.361111111111111. The corrected code gives a better result of 0.24999999999999994.